### PR TITLE
Fix failed to commit and rollback the connection while throw sql exception

### DIFF
--- a/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/dao/DBThriftSessionDAO.java
+++ b/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/dao/DBThriftSessionDAO.java
@@ -65,11 +65,13 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                     thriftSessions.add(thriftSession);
                 }
             }
+            connection.commit();
         } catch (AuthenticationException e) {
             String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
             log.error(errorMsg, e);
             throw IdentityException.error(errorMsg, e);
         } catch (SQLException e) {
+            ThriftAuthenticationDatabaseUtil.rollBack(connection);
             log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.GET_ALL_THRIFT_SESSIONS_SQL);
             log.error(e.getMessage(), e);
             throw IdentityException.error("Error when reading the thrift session information from " +
@@ -97,11 +99,13 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
             if (rSet.next()) {
                 isExistingProvider = true;
             }
+            connection.commit();
         } catch (AuthenticationException e) {
             String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
             log.error(errorMsg, e);
             throw IdentityException.error(errorMsg, e);
         } catch (SQLException e) {
+            ThriftAuthenticationDatabaseUtil.rollBack(connection);
             log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.CHECK_EXISTING_THRIFT_SESSION_SQL);
             log.error(e.getMessage(), e);
             throw IdentityException.error("Error when reading thrift session information from " +
@@ -137,6 +141,7 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                 log.error(errorMsg, e);
                 throw IdentityException.error(errorMsg, e);
             } catch (SQLException e) {
+                ThriftAuthenticationDatabaseUtil.rollBack(connection);
                 log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + sqlStmt);
                 log.error(e.getMessage(), e);
                 throw IdentityException.error("Error when adding a new thrift session.");
@@ -170,6 +175,7 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                 log.error(errorMsg, e);
                 throw IdentityException.error(errorMsg, e);
             } catch (SQLException e) {
+                ThriftAuthenticationDatabaseUtil.rollBack(connection);
                 log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.DELETE_SESSION_SQL);
                 log.error(e.getMessage(), e);
                 throw IdentityException.error("Error deleting the Thrift Session.");
@@ -209,6 +215,7 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                 log.error(errorMsg, e);
                 throw IdentityException.error(errorMsg, e);
             } catch (SQLException e) {
+                ThriftAuthenticationDatabaseUtil.rollBack(connection);
                 log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.UPDATE_LAST_MODIFIED_TIME_SQL);
                 log.error(e.getMessage(), e);
                 throw IdentityException.error("Error updating the Thrift Session.");
@@ -242,11 +249,13 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                     thriftSession.setLastAccess(rSet.getLong(4));
                 }
             }
+            connection.commit();
         } catch (AuthenticationException e) {
             String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
             log.error(errorMsg, e);
             throw IdentityException.error(errorMsg, e);
         } catch (SQLException e) {
+            ThriftAuthenticationDatabaseUtil.rollBack(connection);
             log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.GET_THRIFT_SESSION_SQL);
             log.error(e.getMessage(), e);
             throw IdentityException.error("Error when reading the Thrift session information from " +

--- a/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/dao/DBThriftSessionDAO.java
+++ b/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/dao/DBThriftSessionDAO.java
@@ -65,13 +65,13 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                     thriftSessions.add(thriftSession);
                 }
             }
-            connection.commit();
+            ThriftAuthenticationDatabaseUtil.commitTransaction(connection);
         } catch (AuthenticationException e) {
             String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
             log.error(errorMsg, e);
             throw IdentityException.error(errorMsg, e);
         } catch (SQLException e) {
-            ThriftAuthenticationDatabaseUtil.rollBack(connection);
+            ThriftAuthenticationDatabaseUtil.rollbackTransaction(connection);
             log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.GET_ALL_THRIFT_SESSIONS_SQL);
             log.error(e.getMessage(), e);
             throw IdentityException.error("Error when reading the thrift session information from " +
@@ -99,13 +99,13 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
             if (rSet.next()) {
                 isExistingProvider = true;
             }
-            connection.commit();
+            ThriftAuthenticationDatabaseUtil.commitTransaction(connection);
         } catch (AuthenticationException e) {
             String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
             log.error(errorMsg, e);
             throw IdentityException.error(errorMsg, e);
         } catch (SQLException e) {
-            ThriftAuthenticationDatabaseUtil.rollBack(connection);
+            ThriftAuthenticationDatabaseUtil.rollbackTransaction(connection);
             log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.CHECK_EXISTING_THRIFT_SESSION_SQL);
             log.error(e.getMessage(), e);
             throw IdentityException.error("Error when reading thrift session information from " +
@@ -134,14 +134,14 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
 
                 prepStmt.execute();
 
-                connection.commit();
+                ThriftAuthenticationDatabaseUtil.commitTransaction(connection);
 
             } catch (AuthenticationException e) {
                 String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
                 log.error(errorMsg, e);
                 throw IdentityException.error(errorMsg, e);
             } catch (SQLException e) {
-                ThriftAuthenticationDatabaseUtil.rollBack(connection);
+                ThriftAuthenticationDatabaseUtil.rollbackTransaction(connection);
                 log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + sqlStmt);
                 log.error(e.getMessage(), e);
                 throw IdentityException.error("Error when adding a new thrift session.");
@@ -168,14 +168,14 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                 prepStmt.setString(1, sessionId);
 
                 prepStmt.execute();
-                connection.commit();
+                ThriftAuthenticationDatabaseUtil.commitTransaction(connection);
 
             } catch (AuthenticationException e) {
                 String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
                 log.error(errorMsg, e);
                 throw IdentityException.error(errorMsg, e);
             } catch (SQLException e) {
-                ThriftAuthenticationDatabaseUtil.rollBack(connection);
+                ThriftAuthenticationDatabaseUtil.rollbackTransaction(connection);
                 log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.DELETE_SESSION_SQL);
                 log.error(e.getMessage(), e);
                 throw IdentityException.error("Error deleting the Thrift Session.");
@@ -208,14 +208,14 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                 if (log.isDebugEnabled()) {
                     log.debug("No. of records updated for updating Thrift Session : " + count);
                 }
-                connection.commit();
+                ThriftAuthenticationDatabaseUtil.commitTransaction(connection);
 
             } catch (AuthenticationException e) {
                 String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
                 log.error(errorMsg, e);
                 throw IdentityException.error(errorMsg, e);
             } catch (SQLException e) {
-                ThriftAuthenticationDatabaseUtil.rollBack(connection);
+                ThriftAuthenticationDatabaseUtil.rollbackTransaction(connection);
                 log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.UPDATE_LAST_MODIFIED_TIME_SQL);
                 log.error(e.getMessage(), e);
                 throw IdentityException.error("Error updating the Thrift Session.");
@@ -249,13 +249,13 @@ public class DBThriftSessionDAO implements ThriftSessionDAO {
                     thriftSession.setLastAccess(rSet.getLong(4));
                 }
             }
-            connection.commit();
+            ThriftAuthenticationDatabaseUtil.commitTransaction(connection);
         } catch (AuthenticationException e) {
             String errorMsg = ERROR_WHEN_GETTING_AN_IDENTITY_PERSISTENCE_STORE_INSTANCE;
             log.error(errorMsg, e);
             throw IdentityException.error(errorMsg, e);
         } catch (SQLException e) {
-            ThriftAuthenticationDatabaseUtil.rollBack(connection);
+            ThriftAuthenticationDatabaseUtil.rollbackTransaction(connection);
             log.error(ERROR_WHEN_EXECUTING_THE_SQL + " " + ThriftAuthenticationConstants.GET_THRIFT_SESSION_SQL);
             log.error(e.getMessage(), e);
             throw IdentityException.error("Error when reading the Thrift session information from " +

--- a/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/internal/persistance/ThriftAuthenticationJDBCPersistenceManager.java
+++ b/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/internal/persistance/ThriftAuthenticationJDBCPersistenceManager.java
@@ -122,4 +122,37 @@ public class ThriftAuthenticationJDBCPersistenceManager {
         }
     }
 
+    /**
+     * Revoke the transaction when catch then sql transaction errors.
+     *
+     * @param dbConnection database connection.
+     * @throws SQLException SQL Exception.
+     */
+    public void rollbackTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.rollback();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while rolling back transactions. ", e1);
+        }
+    }
+
+    /**
+     * Commit the transaction.
+     *
+     * @param dbConnection database connection.
+     * @throws SQLException SQL Exception.
+     */
+    public void commitTransaction(Connection dbConnection) {
+
+        try {
+            if (dbConnection != null) {
+                dbConnection.commit();
+            }
+        } catch (SQLException e1) {
+            log.error("An error occurred while commit transactions. ", e1);
+        }
+    }
 }

--- a/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/internal/util/ThriftAuthenticationDatabaseUtil.java
+++ b/components/org.wso2.carbon.identity.authenticator.thrift/src/main/java/org/wso2/carbon/identity/thrift/authentication/internal/util/ThriftAuthenticationDatabaseUtil.java
@@ -90,13 +90,21 @@ public class ThriftAuthenticationDatabaseUtil {
 
     }
 
-    public static void rollBack(Connection dbConnection) {
+    public static void rollbackTransaction(Connection dbConnection) {
+
         try {
-            if (dbConnection != null) {
-                dbConnection.rollback();
-            }
-        } catch (SQLException e1) {
-            log.error("An error occurred while rolling back transactions. ", e1);
+            ThriftAuthenticationJDBCPersistenceManager.getInstance().rollbackTransaction(dbConnection);
+        } catch (AuthenticationException e) {
+            log.error("Error when getting an Identity Persistence Store instance", e);
+        }
+    }
+
+    public static void commitTransaction(Connection dbConnection) {
+
+        try {
+            ThriftAuthenticationJDBCPersistenceManager.getInstance().commitTransaction(dbConnection);
+        } catch (AuthenticationException e) {
+            log.error("Error when getting an Identity Persistence Store instance", e);
         }
     }
 


### PR DESCRIPTION

### Proposed changes in this pull request

When we use the JDBC transaction by applying connection.commit() to commit the SQL statements and make sure SQL statements within a transaction block are all executed successfully. if either one of the SQL statement within the transaction block is failed, abort and rollback everything within the transaction block.
In the identity-carbon-auth-thrift repository, there are some places use the JDBC transaction but did not properly rollback the transaction.

Issue: https://github.com/wso2/product-is/issues/5438